### PR TITLE
align time module

### DIFF
--- a/pyts2/pipeline/align_time.py
+++ b/pyts2/pipeline/align_time.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2018 Gareth Dunstone <gareth.dunstone@anu.edu.au>
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from .base import PipelineStep
+from datetime_truncate import truncate
+
+class AlignStep(PipelineStep):
+
+    def __init__(self, truncate_to='5_minute'):
+        self.truncate_to = truncate_to
+
+    def process_image(self, image):
+        image.datetime = truncate(image.datetime, self.truncate_to)
+        return image

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ msgpack
 numpy
 iso8601
 rawpy
+datetime_truncate


### PR DESCRIPTION
added align time module

added [datetime_truncate](https://github.com/gaqzi/datetime_truncate) to dependencies because its easy, "recently"
had development activity and provides the functionality for time
truncation that is missing in python datetime builtin module