### PR TITLE
Sorted iteration of Version 1 timestreams

### DIFF
--- a/pyts2/test/test_timestreamv1.py
+++ b/pyts2/test/test_timestreamv1.py
@@ -20,11 +20,17 @@ def test_read():
     ]
 
     for timestream in timestreams:
-        for image in TSv1Stream(timestream):
+        last_time = None
+        stream = TSv1Stream(timestream)
+        for image in stream:
+            assert stream.sorted == ('tar' not in timestream)
             assert image.subsecond == 0
             assert image.index is None
             assert np.array_equal(image.pixels, SMALL_TIMESTREAMS["expect_pixels"])
             assert image.datetime in SMALL_TIMESTREAMS["expect_times"]
+            if stream.sorted and last_time is not None:
+                assert image.datetime >= last_time
+            last_time = image.datetime
 
     indices = []
     for image in TSv1Stream("testdata/timestreams/gvlike"):
@@ -32,7 +38,7 @@ def test_read():
         assert image.subsecond == 0
         assert np.array_equal(image.pixels, SMALL_TIMESTREAMS["expect_pixels"])
         assert image.datetime in SMALL_TIMESTREAMS["expect_times"]
-    indices.sort()
+    # images should have been in order
     assert indices == ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10"]
 
 def test_zipout(tmpdir):

--- a/pyts2/tsformats/tsv1.py
+++ b/pyts2/tsformats/tsv1.py
@@ -48,6 +48,13 @@ def path_is_timestream_file(path, extensions=None):
     except ValueError:
         return False
 
+def extract_datetime(path):
+    m = TS_IMAGE_DATETIME_RE.search(path)
+    if m is None:
+        return path
+    else:
+        return m[0]
+
 
 class TSv1Stream(object):
     bundle_levels = ("root", "year", "month", "day", "hour", "none")
@@ -84,7 +91,7 @@ class TSv1Stream(object):
                 with zipfile.ZipFile(str(path)) as zip:
                     # ensure sorted iteration
                     entries = zip.infolist()
-                    entries.sort(key=lambda entry: entry.filename)
+                    entries.sort(key=lambda entry: extract_datetime(entry.filename))
                     for entry in entries:
                         if entry.is_dir():
                             continue
@@ -114,7 +121,7 @@ class TSv1Stream(object):
         for root, dirs, files in os.walk(self.path):
             # ensure sorted iteration
             dirs.sort()
-            files.sort()
+            files.sort(key=lambda f: extract_datetime(f))
             for file in files:
                 path = op.join(root, file)
                 if is_archive(path):

--- a/pyts2/tsformats/tsv1.py
+++ b/pyts2/tsformats/tsv1.py
@@ -59,6 +59,7 @@ class TSv1Stream(object):
         self.path = None
         self.format = None
         self.rawparams = raw_process_params
+        self.sorted = True
         if bundle_level not in self.bundle_levels:
             raise ValueError("invalid bundle level %s",  bundle_level)
         self.bundle = bundle_level
@@ -81,13 +82,18 @@ class TSv1Stream(object):
         def walk_archive(path):
             if zipfile.is_zipfile(str(path)):
                 with zipfile.ZipFile(str(path)) as zip:
-                    for entry in zip.infolist():
+                    # ensure sorted iteration
+                    entries = zip.infolist()
+                    entries.sort(key=lambda entry: entry.filename)
+                    for entry in entries:
                         if entry.is_dir():
                             continue
                         if path_is_timestream_file(entry.filename, extensions=self.format):
                             yield TSImage(image=zip.read(entry),
                                           filename=entry.filename)
             elif tarfile.is_tarfile(path):
+                self.sorted = False
+                warnings.warn("Extracting images from a tar file. Sorted iteration is not guaranteed")
                 with tarfile.TarFile(path) as tar:
                     for entry in tar:
                         if not entry.isfile():
@@ -106,6 +112,9 @@ class TSv1Stream(object):
             yield from walk_archive(self.path)
 
         for root, dirs, files in os.walk(self.path):
+            # ensure sorted iteration
+            dirs.sort()
+            files.sort()
             for file in files:
                 path = op.join(root, file)
                 if is_archive(path):


### PR DESCRIPTION
Closes #19. Iteration is guaranteed to be in order of the timestamp + subsec + index part of file names (and therefore should be sorted by time), so long as no tar files are in the input.