### PR TITLE
Fix naming of timestream bundles

### DIFF
--- a/pyts2/timestream.py
+++ b/pyts2/timestream.py
@@ -273,7 +273,7 @@ class TimeStream(object):
                 fh.write(file.content)
         else:
             if self.bundle == "root":
-                self.path = str(path)
+                self.path = str(self.path)
                 for ext in [".tar", ".zip", f".{self.format}"]:
                     if self.path.lower().endswith(ext):
                         self.path = self.path[:-len(ext)]

--- a/tests/test_timestream.py
+++ b/tests/test_timestream.py
@@ -49,7 +49,7 @@ def test_zipout(tmpdir):
 
     outputs = {
         "root":  [
-            "output.zip",
+            "output.tif.zip",
         ],
         "year":  [
             "output/output_2001.tif.zip",
@@ -89,8 +89,6 @@ def test_zipout(tmpdir):
 
     for level in outputs.keys():
         outpath = tmpdir.join(level, "output")
-        if level == "root":
-            outpath += ".zip"
         out = TimeStream(path=outpath, format="tif", bundle_level=level, name="output")
         for file in TimeStream("testdata/timestreams/nested"):
             out.write(file)

--- a/tests/test_timestream.py
+++ b/tests/test_timestream.py
@@ -96,4 +96,4 @@ def test_zipout(tmpdir):
         check_output_ok(outpath)
 
         expect = {str(tmpdir.join(level, x)) for x in outputs[level]}
-        assert set(find_files(outpath)) == expect
+        assert set(find_files(tmpdir.join(level))) == expect


### PR DESCRIPTION
Currently, the names of timestreams with root-level bundling (i.e. all one zip file) are a bit whacky. this should fix that.