### PR TITLE
Implement zip overwrite protection

### DIFF
--- a/pyts2/filelock.py
+++ b/pyts2/filelock.py
@@ -27,6 +27,7 @@
 import os
 import time
 import errno
+import random
 
 class FileLockException(Exception):
     pass
@@ -52,16 +53,17 @@ class FileLock(object):
 
     def acquire(self):
         """ Acquire the lock, if possible. If the lock is in use, it check again
-            every `wait` seconds. It does this until it either gets the lock or
+            every `delay` seconds. It does this until it either gets the lock or
             exceeds `timeout` number of seconds, in which case it throws
             an exception.
         """
+        time.sleep(random.randrange(1, 10) / 1000)  # 1-10 millisec delay
         start_time = time.time()
         while True:
             try:
                 self.fd = os.open(self.lockfile, os.O_CREAT|os.O_EXCL|os.O_RDWR)
                 self.is_locked = True #moved to ensure tag only when locked
-                break;
+                break
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     raise

--- a/pyts2/timestream.py
+++ b/pyts2/timestream.py
@@ -15,6 +15,7 @@ from queue import Queue
 from threading import Thread
 from pathlib import Path
 import hashlib
+import zlib
 
 from pyts2.time import *
 from pyts2.utils import *
@@ -331,11 +332,12 @@ class TimeStream(object):
             with FileLock(bundle):
                 with zipfile.ZipFile(bundle, mode="a", compression=zipfile.ZIP_STORED,
                                      allowZip64=True) as zip:
-                    if subpath not in zip.namelist():
-                        zip.writestr(op.join(self.name, subpath), file.content)
+                    pathinzip = op.join(self.name, subpath)
+                    if pathinzip not in zip.namelist():
+                        zip.writestr(pathinzip, file.content)
                     else:
                         file_crc = zlib.crc32(file.content)
-                        zip_crc = zip.getinfo(subpath).CRC
+                        zip_crc = zip.getinfo(pathinzip).CRC
                         if file_crc != zip_crc:
                             raise RuntimeError(f"ERROR: trying to overwrite file with different content: zip={bundle}, subpath={subpath}")
 

--- a/tests/test_timestream.py
+++ b/tests/test_timestream.py
@@ -30,7 +30,7 @@ def test_read(data):
             if stream.sorted:
                 assert file.instant == expect_insts[i]
 
-        assert stream.instants == expect_insts
+        assert list(sorted(stream.instants.keys())) == expect_insts
 
 
 def test_gvlike(data):
@@ -149,4 +149,17 @@ def test_read_with_filter(data):
                 assert file.instant == expect_insts[i]
             else:
                 assert file.instant in expect_insts
-        assert stream.instants == expect_insts
+        assert list(sorted(stream.instants.keys())) == expect_insts
+
+def test_zip_overwrite(data, tmpdir):
+    in_stream = TimeStream(data("timestreams/nested"))
+    out_stream = TimeStream(path=tmpdir.join("test_ts.zip"), bundle_level='root', name="output")
+    
+    file = next(in_stream.iter())
+
+    out_stream.write(file)
+    out_stream.write(file)
+    file.clear_content()
+    file._content = b"this isn't the correct content"
+    with pytest.raises(RuntimeError):
+        out_stream.write(file)


### PR DESCRIPTION
This avoids silent dropping of updates to zip files. we still don't handle this nicely, but at least it's now an error (we still silently ignore not being able to write non-updated content, because if the content is the same, we don't care)